### PR TITLE
feat(android): use AndroidX ContextCompat

### DIFF
--- a/android/src/main/java/com/nearit/connectivity/RNConnectivityStatusModule.java
+++ b/android/src/main/java/com/nearit/connectivity/RNConnectivityStatusModule.java
@@ -6,7 +6,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.pm.PackageManager;
 import android.location.LocationManager;
-import android.support.v4.content.ContextCompat;
+import androidx.core.content.ContextCompat;
 
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;


### PR DESCRIPTION
This enables AndroidX and removes the use for now obsolete Jetifier